### PR TITLE
Builder Boosts - add Fertile Soil

### DIFF
--- a/SODBuilderBoost/Config/Localization.txt
+++ b/SODBuilderBoost/Config/Localization.txt
@@ -1,0 +1,3 @@
+Key,File,Type,UsedInMainMenu,english
+terrDirtFertile,blocks,Terrain,,Fertile Soil
+terrDirtFertileDesc,blocks,Terrain,,With this soil blend you can plant crops without requiring a farm plot block.

--- a/SODBuilderBoost/Config/blocks.xml
+++ b/SODBuilderBoost/Config/blocks.xml
@@ -50,4 +50,35 @@ blocks.xml
     <set xpath="blocks/block[@name='treeOakMed02' or @name='treePlantedOak27m' or @name='treeMountainPine27m' or @name='treeMountainPine31m' or @name='treeMountainPineDry21m' or @name='treePineBurntMed' or @name='treePineBurntFullMed' or @name='treePlantedMountainPine27m' or @name='treeWinterPine19m' or @name='treePlantedWinterPine19m' or @name='treeBurntMaple02']/drop[@event='Harvest' and @name='resourceWood']/@count">550</set>
     <set xpath="blocks/block[@name='treeOakLrg01' or @name='treePlantedOak41m' or @name='treeMountainPine41m' or @name='treeMountainPine48m' or @name='treePineBurntLrg' or @name='treeFirLrg01' or @name='treePlantedMountainPine41m' or @name='treeWinterPine28m' or @name='treePlantedWinterPine28m' or @name='treeBurntMaple03']/drop[@event='Harvest' and @name='resourceWood']/@count">800</set>
 
+    <!-- SJ: Add fertile soil block to let builders place plants on terrain -->
+
+    <append xpath="/blocks/">
+        <block name="terrDirtFertile">
+            <property name="CustomIcon" value="terrDirt"/>
+            <property name="DescriptionKey" value="terrDirtFertileDesc"/>
+            <property name="Material" value="Mfarmland"/>
+            <property name="Shape" value="Terrain"/>
+            <property name="Mesh" value="terrain"/>
+            <property name="Texture" value="47"/>
+            <property name="ImposterExclude" value="true"/>
+            <property name="LPHardnessScale" value="2"/>
+            <property name="Map.Color" value="20,50,21"/>
+            <property class="RepairItems">
+                <property name="resourceClayLump" value="14"/>
+            </property>
+            <drop event="Harvest" name="resourceClayLump" count="22" tag="oreWoodHarvest"/>
+	        <drop event="Harvest" name="resourcePotassiumNitratePowder" count="4" tag="oreWoodHarvest"/>
+            <drop event="Destroy" count="0"/>
+            <drop event="Fall" name="terrDirt" count="1" prob="0.25" stick_chance="1"/>
+            <drop event="Fall" name="resourceClayLump" count="44" prob="0.187" stick_chance="0"/>
+            <property name="CanMobsSpawnOn" value="true"/>
+            <property name="EconomicValue" value="5"/>
+            <property name="EconomicBundleSize" value="1"/>
+            <property name="SellableToTrader" value="false"/>
+            <property name="FilterTags" value="fterrain"/>
+            <property name="SortOrder1" value="d0k0"/>
+            <property name="SortOrder2" value="0050"/>
+            <property name="DisplayType" value="blockTerrainFertile"/>
+        </block>
+    </append>
 </configs>

--- a/SODBuilderBoost/Config/blocks.xml
+++ b/SODBuilderBoost/Config/blocks.xml
@@ -52,14 +52,14 @@ blocks.xml
 
     <!-- SJ: Add fertile soil block to let builders place plants on terrain -->
 
-    <append xpath="/blocks/">
+    <append xpath="/blocks">
         <block name="terrDirtFertile">
-            <property name="CustomIcon" value="terrDirt"/>
+            <property name="CustomIcon" value="resourceFertilizer"/>
             <property name="DescriptionKey" value="terrDirtFertileDesc"/>
             <property name="Material" value="Mfarmland"/>
             <property name="Shape" value="Terrain"/>
             <property name="Mesh" value="terrain"/>
-            <property name="Texture" value="47"/>
+            <property name="Texture" value="2"/>
             <property name="ImposterExclude" value="true"/>
             <property name="LPHardnessScale" value="2"/>
             <property name="Map.Color" value="20,50,21"/>

--- a/SODBuilderBoost/Config/recipes.xml
+++ b/SODBuilderBoost/Config/recipes.xml
@@ -1,0 +1,23 @@
+<!--
+Sam's Outback Decay Builder Boosts
+v19.5.1
+by saminal
+untested, good luck
+
+recipes.xml
+-->
+
+<configs>
+
+    <append xpath="/recipes">
+        <recipe name="terrDirtFertile" count="1" tags="perkLivingOffTheLandCrafting" craft_time="20">
+            <ingredient name="foodRottingFlesh" count="10"/>
+            <ingredient name="resourcePotassiumNitratePowder" count="25"/>
+            <ingredient name="resourceClayLump" count="100"/>
+            <effect_group>
+                <passive_effect name="CraftingIngredientCount" level="1,2,3" operation="perc_add" value="-.3,-.5,-.5" tags="foodRottingFlesh,resourcePotassiumNitratePowder,resourceClayLump"/>
+            </effect_group>
+        </recipe>
+    </append>
+    
+</configs>


### PR DESCRIPTION
Add terrain block that serves the same purpose as the farm plot but allows smoother garden planting